### PR TITLE
update twowaysql version for ruby 2.1 support

### DIFF
--- a/dm-twowaysql.gemspec
+++ b/dm-twowaysql.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.version       = DataMapper::TwoWaySQL::VERSION
 
   gem.add_runtime_dependency('dm-do-adapter', '~> 1.2.0')
-  gem.add_runtime_dependency('twowaysql', '~> 0.5.0')
+  gem.add_runtime_dependency('twowaysql', '~> 0.6.0')
 
   gem.add_development_dependency('rake', '~> 0.9.2')
   gem.add_development_dependency('rspec', '~> 1.3.2')


### PR DESCRIPTION
I'd like to use ruby 2.1
https://github.com/twada/twowaysql/pull/1
